### PR TITLE
TODO-655: trimming code

### DIFF
--- a/Arduino/V0p2_Main/UI_Minimal.cpp
+++ b/Arduino/V0p2_Main/UI_Minimal.cpp
@@ -117,12 +117,14 @@ static void inline offPause()
 // Counts calls to tickUI.
 static uint8_t tickCount;
 
+
 // Call this on even numbered seconds (with current time in seconds) to allow the UI to operate.
 // Should never be skipped, so as to allow the UI to remain responsive.
 // Runs in 350ms or less; usually takes only a few milliseconds or microseconds.
 // Returns true iff the user interacted with the system, and maybe caused a status change.
 // NOTE: since this is on the minimum idle-loop code path, minimise CPU cycles, esp in frost mode.
 // Also re-activates CLI on main button push.
+#ifndef tickUI
 bool tickUI(const uint_fast8_t sec)
   {
   // Perform any once-per-minute operations.
@@ -353,6 +355,7 @@ bool tickUI(const uint_fast8_t sec)
   statusChange = false; // Potential race.
   return(statusChanged);
   }
+#endif // tickUI
 
 
 // Check/apply the user's schedule, at least once each minute, and act on any timed events.

--- a/Arduino/V0p2_Main/UI_Minimal.h
+++ b/Arduino/V0p2_Main/UI_Minimal.h
@@ -74,7 +74,16 @@ The OpenTRV project licenses this file to you
 // Returns true iff the user interacted with the system, and maybe caused a status change.
 // NOTE: since this is on the minimum idle-loop code path, minimise CPU cycles, esp in frost mode.
 // Also re-activates CLI on main button push.
+//
+#if !defined(BUTTON_MODE_L) || (!defined(LOCAL_TRV) && !defined(SLAVE_TRV))
+// If the appropriate button input is not available
+// or this is not driving a local TRV (eg because this is a sensor module)
+// then disable the usual interactive UI entirely.
+#define NO_UI_SUPPORT
+#define tickUI(sec) (false) // Always false.
+#else
 bool tickUI(uint_fast8_t sec);
+#endif
 
 // Record local manual operation of a local physical UI control, eg not remote or via CLI.
 // Thread-safe.

--- a/Arduino/V0p2_Main/V0p2_Board_IO_Config.h
+++ b/Arduino/V0p2_Main/V0p2_Board_IO_Config.h
@@ -107,11 +107,12 @@ Author(s) / Copyright (s): Damon Hart-Davis 2013--2015
 #endif
 
 // UI main 'mode' button (active/pulled low by button, pref using weak internal pull-up), digital in.
+// Should always be available where a local TRV is being controlled.
 // NOT AVAILABLE FOR REV10 (used for GSM module TX pin).
-//#if (V0p2_REV != 10) // FIXME rest of V0p2_Main assumes there is always a mode button
-#define BUTTON_MODE_L 5 // ATMega328P-PU PDIP pin 11, PD5, PCINT21, no analogue input.
 #if (V0p2_REV == 10)	// FIXME might be better to define pins by peripheral
 #define SIM900_TX_PIN 5
+#else
+#define BUTTON_MODE_L 5 // ATMega328P-PU PDIP pin 11, PD5, PCINT21, no analogue input.
 #endif
 
 #ifdef LEARN_BUTTON_AVAILABLE
@@ -235,7 +236,12 @@ static inline void IOSetup()
 
       // Make button pins (and others) inputs with internal weak pull-ups
       // (saving an external resistor in each case if aggressively reducing BOM costs).
-      case BUTTON_MODE_L: // Mode button is mandatory.
+#ifdef BUTTON_MODE_L
+      case BUTTON_MODE_L: // Mode button is (usually!) mandatory, at least where a local TRV is being controlled.
+#endif
+#ifdef SIM900_TX_PIN
+      case SIM900_TX_PIN: // When driving SIM900 this pin has external pull-up so should start high.
+#endif
 #ifdef BUTTON_LEARN_L
       case BUTTON_LEARN_L: // Learn button is optional.
 #endif


### PR DESCRIPTION
Eliminating UI for non-TRV-controlling boards.
Saves 424 bytes and some confusion!